### PR TITLE
macros: add compilation tests

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -81,7 +81,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: -Zbuild-std=std --target x86_64-unknown-linux-gnu --features=exts
+          args: -Zbuild-std=std --target x86_64-unknown-linux-gnu --features=exts --package uefi --package uefi-macros
 
   lints:
     name: Lints

--- a/uefi-macros/Cargo.toml
+++ b/uefi-macros/Cargo.toml
@@ -22,3 +22,7 @@ proc-macro = true
 proc-macro2 = "1.0.28"
 quote = "1.0.9"
 syn = { version = "1.0.75", features = ["full"] }
+
+[dev-dependencies]
+trybuild = "1.0"
+uefi = { version = "0.12.0", default-features = false }

--- a/uefi-macros/tests/cargo_wrapper
+++ b/uefi-macros/tests/cargo_wrapper
@@ -1,0 +1,2 @@
+#!/bin/sh
+cargo -Zbuild-std=std "$@"

--- a/uefi-macros/tests/compilation.rs
+++ b/uefi-macros/tests/compilation.rs
@@ -1,0 +1,17 @@
+use std::env;
+
+#[test]
+fn ui() {
+    let t = trybuild::TestCases::new();
+
+    // This wrapper script adds the necessary `-Zbuild-std` argument
+    // when trybuild invokes cargo.
+    let cargo_wrapper = env::current_exe()
+        .unwrap()
+        .parent()
+        .unwrap()
+        .join("../../../../uefi-macros/tests/cargo_wrapper");
+    env::set_var("CARGO", cargo_wrapper);
+
+    t.compile_fail("tests/ui/*.rs");
+}

--- a/uefi-macros/tests/ui/entry.rs
+++ b/uefi-macros/tests/ui/entry.rs
@@ -1,0 +1,77 @@
+#![no_main]
+#![feature(abi_efiapi)]
+
+use uefi::prelude::*;
+use uefi_macros::entry;
+
+mod good_entry {
+    use super::*;
+
+    #[entry]
+    fn efi_main(_handle: Handle, _st: SystemTable<Boot>) -> Status {
+        Status::SUCCESS
+    }
+}
+
+mod bad_attr_arg {
+    use super::*;
+
+    #[entry(some_arg)]
+    extern "C" fn efi_main(_handle: Handle, _st: SystemTable<Boot>) -> Status {
+        Status::SUCCESS
+    }
+}
+
+mod bad_abi_modifier {
+    use super::*;
+
+    #[entry]
+    extern "C" fn efi_main(_handle: Handle, _st: SystemTable<Boot>) -> Status {
+        Status::SUCCESS
+    }
+}
+
+mod bad_async {
+    use super::*;
+
+    #[entry]
+    async fn efi_main(_handle: Handle, _st: SystemTable<Boot>) -> Status {
+        Status::SUCCESS
+    }
+}
+
+mod bad_const {
+    use super::*;
+
+    #[entry]
+    const fn efi_main(_handle: Handle, _st: SystemTable<Boot>) -> Status {
+        Status::SUCCESS
+    }
+}
+
+mod bad_generic {
+    use super::*;
+
+    #[entry]
+    fn efi_main<T>(_handle: Handle, _st: SystemTable<Boot>) -> Status {
+        Status::SUCCESS
+    }
+}
+
+mod bad_args {
+    use super::*;
+
+    #[entry]
+    fn efi_main(_handle: Handle, _st: SystemTable<Boot>, _x: usize) -> bool {
+        false
+    }
+}
+
+mod bad_return_type {
+    use super::*;
+
+    #[entry]
+    fn efi_main(_handle: Handle, _st: SystemTable<Boot>) -> bool {
+        false
+    }
+}

--- a/uefi-macros/tests/ui/entry.stderr
+++ b/uefi-macros/tests/ui/entry.stderr
@@ -1,0 +1,53 @@
+error: Entry attribute accepts no arguments
+  --> $DIR/entry.rs:19:13
+   |
+19 |     #[entry(some_arg)]
+   |             ^^^^^^^^
+
+error: Entry method must have no ABI modifier
+  --> $DIR/entry.rs:20:5
+   |
+20 |     extern "C" fn efi_main(_handle: Handle, _st: SystemTable<Boot>) -> Status {
+   |     ^^^^^^^^^^
+
+error: Entry method must have no ABI modifier
+  --> $DIR/entry.rs:29:5
+   |
+29 |     extern "C" fn efi_main(_handle: Handle, _st: SystemTable<Boot>) -> Status {
+   |     ^^^^^^^^^^
+
+error: Entry method should not be async
+  --> $DIR/entry.rs:38:5
+   |
+38 |     async fn efi_main(_handle: Handle, _st: SystemTable<Boot>) -> Status {
+   |     ^^^^^
+
+error: Entry method should not be const
+  --> $DIR/entry.rs:47:5
+   |
+47 |     const fn efi_main(_handle: Handle, _st: SystemTable<Boot>) -> Status {
+   |     ^^^^^
+
+error: Entry method should not be generic
+  --> $DIR/entry.rs:56:17
+   |
+56 |     fn efi_main<T>(_handle: Handle, _st: SystemTable<Boot>) -> Status {
+   |                 ^
+
+error[E0308]: mismatched types
+  --> $DIR/entry.rs:65:8
+   |
+65 |     fn efi_main(_handle: Handle, _st: SystemTable<Boot>, _x: usize) -> bool {
+   |        ^^^^^^^^ incorrect number of function parameters
+   |
+   = note: expected fn pointer `extern "efiapi" fn(uefi::Handle, uefi::table::SystemTable<uefi::table::Boot>) -> uefi::Status`
+                 found fn item `extern "efiapi" fn(uefi::Handle, uefi::table::SystemTable<uefi::table::Boot>, usize) -> bool {bad_args::efi_main}`
+
+error[E0308]: mismatched types
+  --> $DIR/entry.rs:74:8
+   |
+74 |     fn efi_main(_handle: Handle, _st: SystemTable<Boot>) -> bool {
+   |        ^^^^^^^^ expected struct `uefi::Status`, found `bool`
+   |
+   = note: expected fn pointer `extern "efiapi" fn(uefi::Handle, uefi::table::SystemTable<_>) -> uefi::Status`
+                 found fn item `extern "efiapi" fn(uefi::Handle, uefi::table::SystemTable<_>) -> bool {bad_return_type::efi_main}`

--- a/uefi-macros/tests/ui/guid.rs
+++ b/uefi-macros/tests/ui/guid.rs
@@ -1,0 +1,19 @@
+use uefi_macros::unsafe_guid;
+
+// The GUID here is OK.
+#[unsafe_guid("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")]
+struct Good;
+
+// Fail because the length is wrong.
+#[unsafe_guid("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaa")]
+struct TooShort;
+
+// Error span should point to the second group.
+#[unsafe_guid("aaaaaaaa-Gaaa-aaaa-aaaa-aaaaaaaaaaaa")]
+struct BadHexGroup2;
+
+// Error span should point to the fifth group.
+#[unsafe_guid("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaG")]
+struct BadHexGroup5;
+
+fn main() {}

--- a/uefi-macros/tests/ui/guid.stderr
+++ b/uefi-macros/tests/ui/guid.stderr
@@ -1,0 +1,17 @@
+error: "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaa" is not a canonical GUID string (expected 36 bytes, found 35)
+ --> $DIR/guid.rs:8:15
+  |
+8 | #[unsafe_guid("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaa")]
+  |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: GUID component "Gaaa" is not a hexadecimal number
+  --> $DIR/guid.rs:12:25
+   |
+12 | #[unsafe_guid("aaaaaaaa-Gaaa-aaaa-aaaa-aaaaaaaaaaaa")]
+   |                         ^^^^
+
+error: GUID component "aaaaaaaaaaaG" is not a hexadecimal number
+  --> $DIR/guid.rs:16:40
+   |
+16 | #[unsafe_guid("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaG")]
+   |                                        ^^^^^^^^^^^^


### PR DESCRIPTION
Use the [trybuild] crate to test the `unsafe_guid` and `entry`
macros. The compilation output is compared against expected output to
check the various error cases in the macros.

Also updated the CI to run these tests, although that change should be
obseleted by https://github.com/rust-osdev/uefi-rs/pull/283.

[trybuild]: https://github.com/dtolnay/trybuild