### PR TITLE
Re-enable multi-processor test in the CI

### DIFF
--- a/uefi-test-runner/Cargo.toml
+++ b/uefi-test-runner/Cargo.toml
@@ -14,7 +14,4 @@ log = { version = "0.4.11", default-features = false }
 qemu-exit = "2.0.0"
 
 [features]
-# This feature should only be enabled in our CI, it disables some tests
-# which currently fail in that environment (see #103 for discussion).
-ci = []
 qemu = ["uefi-services/qemu"]

--- a/uefi-test-runner/build.py
+++ b/uefi-test-runner/build.py
@@ -102,9 +102,6 @@ def build(*test_flags):
     if SETTINGS['config'] == 'release':
         build_args.append('--release')
 
-    if SETTINGS['ci']:
-        build_args.extend(['--features', 'ci'])
-
     run_build(*build_args)
 
     # Copy the built test runner file to the right directory for running tests.

--- a/uefi-test-runner/src/proto/pi/mp.rs
+++ b/uefi-test-runner/src/proto/pi/mp.rs
@@ -9,11 +9,6 @@ use uefi::Status;
 const NUM_CPUS: usize = 4;
 
 pub fn test(bt: &BootServices) {
-    // These tests break CI. See #103.
-    if cfg!(feature = "ci") {
-        return;
-    }
-
     info!("Running UEFI multi-processor services protocol test");
     if let Ok(mp_support) = bt.locate_protocol::<MpServices>() {
         let mp_support = mp_support


### PR DESCRIPTION
From the bug report it sounds like this test used to crash QEMU in the
CI, but that doesn't happen anymore.