### PR TITLE
Move build.py to the root of the repo

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -26,7 +26,6 @@ jobs:
 
     - name: Build
       run: ./build.py build --target aarch64
-      working-directory: ./uefi-test-runner
 
   build_and_test:
     name: Build and run tests on x86_64
@@ -56,11 +55,9 @@ jobs:
 
     - name: Build
       run: ./build.py build
-      working-directory: ./uefi-test-runner
 
     - name: Run VM tests
       run: ./build.py run --headless --ci
-      working-directory: ./uefi-test-runner
 
   test:
     name: Run tests and documentation tests
@@ -78,7 +75,7 @@ jobs:
             override: true
 
       - name: Run cargo test
-        run: uefi-test-runner/build.py test
+        run: ./build.py test
 
   lints:
     name: Lints
@@ -102,7 +99,7 @@ jobs:
           args: --all -- --check
 
       - name: Run clippy
-        run: uefi-test-runner/build.py clippy
+        run: ./build.py clippy
 
       - name: Run cargo doc
         uses: actions-rs/cargo@v1

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,17 +5,8 @@ Pull requests, issues and suggestions are welcome!
 The UEFI spec is huge, so there might be some omissions or some missing features.
 You should follow the existing project structure when adding new items.
 
-## Workflow
-
-First, change to the `uefi-test-runner` directory:
-
-```shell
-cd 'uefi-test-runner'
-```
-
-Please take a quick look at the test runner project's [`README`](uefi-test-runner/README.md)
-for an overview of the required dependencies. In addition, the [`BUILDING`](BUILDING.md)
-document is useful if it's your first time building and running an UEFI executable.
+See the top-level [README](../README.md) for details of using `./build.py` to
+build and test the project.
 
 Make some changes in your favourite editor / IDE:
 I use [VS Code][code] with the [RLS][rls] extension.

--- a/README.md
+++ b/README.md
@@ -63,14 +63,38 @@ the [UEFI specification][spec] for detailed information.
 
 [spec]: http://www.uefi.org/specifications
 
-## Tests
+## Building and testing uefi-rs
+
+Install the `nightly` version of Rust and the `rust-src` component:
+```
+rustup toolchain install nightly
+rustup component add --toolchain nightly rust-src
+```
+
+Use the `./build.py` script to build and test the crate.
+
+Available commands:
+- `build`: build `uefi-test-runner`
+- `clippy`: run clippy on the whole workspace
+- `doc`: build the docs for the library packages
+- `run`: build `uefi-test-runner` and run it in QEMU
+- `test`: run unit tests and doctests on the host
+
+Available options:
+- `--target {x86_64,aarch64}`: choose which architecture to build/run the tests
+- `--verbose`: enables verbose mode, prints commands before running them
+- `--headless`: enables headless mode, which runs QEMU without a GUI
+- `--release`: builds the code with optimizations enabled
+- `--disable-kvm`: disable [KVM](https://www.linux-kvm.org/page/Main_Page) hardware acceleration
+  when running the tests in QEMU (especially useful if you want to run the tests under
+  [WSL](https://docs.microsoft.com/en-us/windows/wsl) on Windows.
 
 The `uefi-test-runner` directory contains a sample UEFI app which exercises
 most of the library's functionality.
 
 Check out the testing project's [`README.md`](uefi-test-runner/README.md) for instructions on how to run the tests.
 
-## Building UEFI programs
+## Building your own UEFI programs
 
 For instructions on how to create your own UEFI apps, see the [BUILDING.md](BUILDING.md) file.
 

--- a/build.py
+++ b/build.py
@@ -14,7 +14,7 @@ import sys
 
 ## Configurable settings
 # Path to workspace directory (which contains the top-level `Cargo.toml`)
-WORKSPACE_DIR = Path(__file__).resolve().parents[1]
+WORKSPACE_DIR = Path(__file__).resolve().parent
 
 # Try changing these with command line flags, where possible
 SETTINGS = {
@@ -68,10 +68,6 @@ def esp_dir():
     'Returns the directory where we will build the emulated UEFI system partition'
     return build_dir() / 'esp'
 
-def repo_dir():
-    'Returns the root directory of the git repo.'
-    return Path(__file__).resolve().parent.parent
-
 def run_tool(tool, *flags):
     'Runs cargo-<tool> with certain arguments.'
 
@@ -103,7 +99,7 @@ def build(*test_flags):
         build_args.append('--release')
 
     if SETTINGS['ci']:
-        build_args.extend(['--features', 'ci'])
+        build_args.extend(['--features', 'uefi-test-runner/ci'])
 
     run_build(*build_args)
 
@@ -127,7 +123,7 @@ def clippy():
     run_clippy(
         # Specifying the manifest path allows this command to
         # run successfully regardless of the CWD.
-        '--manifest-path', repo_dir() / 'Cargo.toml',
+        '--manifest-path', WORKSPACE_DIR / 'Cargo.toml',
         # Lint all packages in the workspace.
         '--workspace',
         # Enable all the features in the uefi package that enable more
@@ -176,7 +172,7 @@ def test():
         'cargo', 'test',
         # Specifying the manifest path allows this command to
         # run successfully regardless of the CWD.
-        '--manifest-path', repo_dir() / 'Cargo.toml',
+        '--manifest-path', WORKSPACE_DIR / 'Cargo.toml',
         '-Zbuild-std=std',
         '--target', get_host_target(),
         '--features', 'exts',
@@ -231,7 +227,7 @@ def run_qemu():
     'Runs the code in QEMU.'
 
     # Rebuild all the changes.
-    build('--features', 'qemu')
+    build('--features', 'uefi-test-runner/qemu')
 
     ovmf_code, ovmf_vars = ovmf_files(find_ovmf())
 

--- a/uefi-test-runner/README.md
+++ b/uefi-test-runner/README.md
@@ -16,29 +16,7 @@ Besides all the [core library requirements](../BUILDING.md) for building a UEFI 
   **Note**: if your distro's OVMF version is too old / does not provide these files,
   you can download [Gerd Hoffmann's builds](https://www.kraxel.org/repos/) and extract them in the local directory.
 
-## Steps
+## Build and run in QEMU
 
-It's as simple as running the `build.py` script with the ``run` argument:
-
-```sh
-./build.py run
-```
-
-Available commands:
-
-- `build`: only build
-- `run`: (re)build and run
-- `doc`: generate documentation
-- `clippy`: run Clippy
-- `test`: run tests and doctests
-
-Available options:
-
-- `--target {x86_64,aarch64}`: choose which architecture to build/run the tests
-- `--verbose`: enables verbose mode, prints commands before running them
-- `--headless`: enables headless mode, which runs QEMU without a GUI
-- `--release`: builds the code with optimizations enabled
-- `--disable-kvm`: disable [KVM](https://www.linux-kvm.org/page/Main_Page) hardware acceleration
-  when running the tests in QEMU
-
-  This is especially useful if you want to run the tests under [WSL](https://docs.microsoft.com/en-us/windows/wsl/) on Windows.
+Use `./build.py run` to build `uefi-test-runner` and run it in QEMU. See
+the top-level [README](../README.md) for more details of `./build.py`.


### PR DESCRIPTION
build.py isn't really specific to uefi-test-runner; it has commands for
generating docs, running clippy, and running tests. Move it to the root
of the repo to reflect its broader role.

Updated various docs that reference build.py.